### PR TITLE
Provide user the real @return type of `StaticRouter::match()` method

### DIFF
--- a/src/StaticRouter.php
+++ b/src/StaticRouter.php
@@ -41,7 +41,7 @@ class StaticRouter extends Nette\Object implements IRouter
 	/**
 	 * Maps HTTP request to a Request object.
 	 *
-	 * @return AppRequest|NULL
+	 * @return Nette\Application\Request|NULL
 	 */
 	public function match(HttpRequest $httpRequest)
 	{


### PR DESCRIPTION
The method `StaticRouter::match()` does not actually return `AppRequest`, but `Nette\Application\Request` (`AppRequest` is only custom _alias_ in your specific context of StaticRouter.php). One who never looks into code but generated documentation may be confused with unknown return type.
